### PR TITLE
appears we need HTTPS to prevent redirections.  

### DIFF
--- a/lib/scripture_lookup/bible_gateway_scraper.rb
+++ b/lib/scripture_lookup/bible_gateway_scraper.rb
@@ -16,7 +16,7 @@ module ScriptureLookup
     end
 
     def lookup reference, version
-      url = "http://www.biblegateway.com/passage/?search=#{reference}&version=#{version.to_s}"
+      url = "https://www.biblegateway.com/passage/?search=#{reference}&version=#{version.to_s}"
       doc = get_doc(url)
 
       generate_response doc


### PR DESCRIPTION
Why anyone needs HTTPS on a biblegateway page.... ?